### PR TITLE
Units for pressure in entropy calculation

### DIFF
--- a/quacc/util/calc.py
+++ b/quacc/util/calc.py
@@ -446,9 +446,9 @@ def ideal_gas_thermo(
             "pointgroup": pointgroup,
             "energy": energy,
             "enthalpy": igt.get_enthalpy(temperature, verbose=False),
-            "entropy": igt.get_entropy(temperature, pressure / 10**5, verbose=False),
+            "entropy": igt.get_entropy(temperature, pressure * 10**5, verbose=False),
             "gibbs_energy": igt.get_gibbs_energy(
-                temperature, pressure / 10**5, verbose=False
+                temperature, pressure * 10**5, verbose=False
             ),
         },
     }


### PR DESCRIPTION
ASE.IdealGasThermo.get_entropy() requires pressure in Pa; 1 bar = 1e5 Pa