### PR TITLE
Re-enable dftbplus unit tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,7 @@ jobs:
           pip install .[tests]
           pip install pytest-cov
           conda install -c psi4 psi4
-          conda install -c conda-forge xtb-python # dftbplus
+          conda install -c conda-forge xtb-python dftbplus
           
       - name: Run tests with pytest
         run: pytest --cov=quacc --cov-report=xml

--- a/tests/recipes/dftb/test_dftb_recipes.py
+++ b/tests/recipes/dftb/test_dftb_recipes.py
@@ -83,7 +83,7 @@ def test_relax_job():
     assert output["name"] == "DFTB-Relax"
     assert output["parameters"]["Hamiltonian_"] == "xTB"
     assert output["parameters"]["Hamiltonian_Method"] == "GFN2-xTB"
-    assert output["results"]["energy"] == pytest.approx(-137.98336133558837)
+    assert output["results"]["energy"] == pytest.approx(-137.97654214864497)
     assert (
         np.array_equal(output["atoms"].get_positions(), atoms.get_positions()) is False
     )

--- a/tests/recipes/dftb/test_dftb_recipes.py
+++ b/tests/recipes/dftb/test_dftb_recipes.py
@@ -65,7 +65,7 @@ def test_static_Job():
     assert output["parameters"]["Hamiltonian_KPointsAndWeights_empty000"] == "3 0 0"
     assert output["parameters"]["Hamiltonian_KPointsAndWeights_empty001"] == "0 3 0"
     assert output["parameters"]["Hamiltonian_KPointsAndWeights_empty002"] == "0 0 3"
-    assert output["results"]["energy"] == pytest.approx(-107.55154244254307)
+    assert output["results"]["energy"] == pytest.approx(-106.86647125470942)
 
 
 @pytest.mark.skipif(

--- a/tests/recipes/dftb/test_dftb_recipes.py
+++ b/tests/recipes/dftb/test_dftb_recipes.py
@@ -47,7 +47,7 @@ def test_static_Job():
     assert output["name"] == "DFTB-Static"
     assert output["parameters"]["Hamiltonian_"] == "xTB"
     assert output["parameters"]["Hamiltonian_Method"] == "GFN2-xTB"
-    assert output["results"]["energy"] == pytest.approx(-137.97459675495645)
+    assert output["results"]["energy"] == pytest.approx(-137.9677759924738)
 
     atoms = bulk("Cu")
 


### PR DESCRIPTION
Addresses #105. It looks like a version update to DFTB+ modified the xTB Hamiltonian so the energies are no longer the same.